### PR TITLE
esp-idf support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,6 @@ if(IDF_PATH)
 	idf_component_register(
 		SRCS ${Beauty_Sources}
 		INCLUDE_DIRS "src"
-		REQUIRES
+		REQUIRES asio espressif__sock_utils 
 	)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,24 +1,26 @@
 if(NOT IDF_PATH)
 	cmake_minimum_required(VERSION 3.24)
-	project(beauty
+	project(beauty_library
 		LANGUAGES CXX
 		VERSION 1.0
 	)
 
 	enable_testing()
 
-	file (GLOB Beauty_Sources CONFIGURE_DEPENDS "src/*.cpp")
+	file (GLOB beauty_sources CONFIGURE_DEPENDS "src/*.cpp")
 
 	add_subdirectory(import)
 	add_subdirectory(examples)
 	add_subdirectory(test)
 
-	target_compile_options(beauty_example PRIVATE -Wall -Wextra -Wpedantic -Werror)
+	add_library(${CMAKE_PROJECT_NAME} STATIC ${beauty_sources})
 
-	# Note: Beauty_Sources requires C++11 only however examples/test
-	# requires c++17
-	set_target_properties(beauty_example beauty_test PROPERTIES
-		CXX_STANDARD 17
+	target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE asio::asio)
+
+	target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic -Werror)
+
+	set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
+		CXX_STANDARD 11
 		CXX_STANDARD_REQUIRED YES
 		CXX_EXTENSIONS NO
 	)
@@ -26,10 +28,10 @@ endif()
 
 # --- ESP-IDF component support: only active when included as a component ---
 if(IDF_PATH)
-	file (GLOB Beauty_Sources "src/*.cpp")
+	file (GLOB beauty_sources "src/*.cpp")
 	# Register as ESP-IDF component
 	idf_component_register(
-		SRCS ${Beauty_Sources}
+		SRCS ${beauty_sources}
 		INCLUDE_DIRS "src"
 		REQUIRES asio espressif__sock_utils 
 	)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ if(NOT IDF_PATH)
 	add_subdirectory(examples)
 	add_subdirectory(test)
 
+	target_compile_options(beauty_example PRIVATE -Wall -Wextra -Wpedantic -Werror)
+
 	# Note: Beauty_Sources requires C++11 only however examples/test
 	# requires c++17
 	set_target_properties(beauty_example beauty_test PROPERTIES

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,10 +1,9 @@
 project(beauty_example)
 
-add_executable(beauty_example
+add_executable(${PROJECT_NAME}
 	pc/main.cpp
 	pc/file_io.cpp
 	pc/my_file_api.cpp
-	${Beauty_Sources}
 )
 
 include_directories(
@@ -12,4 +11,6 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/src
 )
 
-target_link_libraries(beauty_example PRIVATE asio::asio)
+target_link_libraries(${PROJECT_NAME} PRIVATE asio::asio ${CMAKE_PROJECT_NAME})
+
+target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic -Werror)

--- a/examples/pc/file_io.cpp
+++ b/examples/pc/file_io.cpp
@@ -7,7 +7,7 @@ using namespace beauty;
 
 FileIO::FileIO(const std::string &docRoot) : docRoot_(docRoot) {}
 
-size_t FileIO::openFileForRead(const std::string &id, const Request &request, Reply &reply) {
+size_t FileIO::openFileForRead(const std::string &id, const Request&, Reply &reply) {
     std::string fullPath = docRoot_ + reply.filePath_;
     std::ifstream &is = openReadFiles_[id];
     is.open(fullPath.c_str(), std::ios::in | std::ios::binary);
@@ -22,7 +22,7 @@ size_t FileIO::openFileForRead(const std::string &id, const Request &request, Re
     return 0;
 }
 
-int FileIO::readFile(const std::string &id, const Request &request, char *buf, size_t maxSize) {
+int FileIO::readFile(const std::string &id, const Request&, char *buf, size_t maxSize) {
     openReadFiles_[id].read(buf, maxSize);
     return openReadFiles_[id].gcount();
 }
@@ -33,9 +33,9 @@ void FileIO::closeReadFile(const std::string &id) {
 }
 
 Reply::status_type FileIO::openFileForWrite(const std::string &id,
-                                            const Request &request,
+                                            const Request&,
                                             Reply &reply,
-                                            std::string &err) {
+                                            std::string&) {
     std::string fullPath = docRoot_ + reply.filePath_;
     std::ofstream &os = openWriteFiles_[id];
     os.open(fullPath.c_str(), std::ios::out | std::ios::binary);
@@ -43,11 +43,11 @@ Reply::status_type FileIO::openFileForWrite(const std::string &id,
 }
 
 Reply::status_type FileIO::writeFile(const std::string &id,
-                                     const Request &request,
+                                     const Request&,
                                      const char *buf,
                                      size_t size,
                                      bool lastData,
-                                     std::string &err) {
+                                     std::string&) {
     openWriteFiles_[id].write(buf, size);
     if (lastData) {
         openWriteFiles_[id].close();

--- a/src/beauty_common.hpp
+++ b/src/beauty_common.hpp
@@ -12,7 +12,6 @@ namespace beauty {
 using handlerCallback = std::function<void(const Request &req, Reply &rep)>;
 
 using debugMsgCallback = std::function<void(const std::string &msg)>;
-static void defaultDebugMsgHandler(const std::string &msg) {}
 
 struct HttpPersistence {
     HttpPersistence(std::chrono::seconds keepAliveTimeout,

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -211,7 +211,7 @@ void Connection::shutdown() {
     std::error_code ignored_ec;
     socket_.shutdown(asio::ip::tcp::socket::shutdown_both, ignored_ec);
     connectionManager_.stop(shared_from_this());
-    requestHandler_.closeFile(reply_, connectionId_);
+    requestHandler_.closeFile(connectionId_);
 }
 
 }  // namespace beauty

--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -63,6 +63,12 @@ class Connection : public std::enable_shared_from_this<Connection> {
     // The handler used to process the incoming request.
     RequestHandler &requestHandler_;
 
+    // The unique id for the connection.
+    unsigned connectionId_;
+
+    // The max buffer size when reading/writing socket.
+    size_t maxContentSize_;
+
     // Buffer for incoming data.
     std::vector<char> buffer_;
 
@@ -78,9 +84,6 @@ class Connection : public std::enable_shared_from_this<Connection> {
     // The reply to be sent back to the client.
     Reply reply_;
 
-    // The unique id for the connection.
-    unsigned connectionId_;
-
     // Last received data timestamp.
     std::chrono::steady_clock::time_point lastReceivedTime_;
 
@@ -95,9 +98,6 @@ class Connection : public std::enable_shared_from_this<Connection> {
 
     // Request counter
     size_t nrOfRequest_ = 0;
-
-    // The max buffer size when reading/writing socket.
-    size_t maxContentSize_;
 };
 
 }  // namespace beauty

--- a/src/connection_manager.cpp
+++ b/src/connection_manager.cpp
@@ -1,6 +1,10 @@
 #include "connection_manager.hpp"
 #include <chrono>
 
+namespace {
+	void defaultDebugMsgHandler(const std::string&) {}
+}
+
 namespace beauty {
 
 ConnectionManager::ConnectionManager(HttpPersistence options)

--- a/src/multipart_parser.cpp
+++ b/src/multipart_parser.cpp
@@ -39,10 +39,9 @@ bool MultiPartParser::parseHeader(const Request &req) {
     return true;
 }
 
-MultiPartParser::result_type MultiPartParser::parse(const Request &req,
-                                                    std::vector<char> &content,
+MultiPartParser::result_type MultiPartParser::parse(std::vector<char> &content,
                                                     std::deque<ContentPart> &parts) {
-    result_type result;
+    result_type result = result_type::indeterminate;
 
     if (content.empty()) {
         return indeterminate;

--- a/src/multipart_parser.hpp
+++ b/src/multipart_parser.hpp
@@ -39,8 +39,7 @@ class MultiPartParser {
     // data is required.
     // The caller must inspect readyParts to see if any parts has been
     // completed.
-    result_type parse(const Request &req,
-                      std::vector<char> &content,
+    result_type parse(std::vector<char> &content,
                       std::deque<ContentPart> &parts);
 
     void flush(std::vector<char> &content, std::deque<ContentPart> &parts);
@@ -75,7 +74,6 @@ class MultiPartParser {
     std::vector<char> &lastBuffer_;
     std::deque<ContentPart> lastParts_;
 
-    size_t contentCount_;
     size_t boundaryCount_;
     std::string boundaryStr_;
 };

--- a/src/reply.hpp
+++ b/src/reply.hpp
@@ -71,7 +71,7 @@ class Reply {
         contentSize_ = 0;
         replyPartial_ = false;
         finalPart_ = false;
-        noBodyBytesReceived_ = -1;
+        noBodyBytesReceived_ = 0;
         isMultiPart_ = false;
         lastOpenFileForWriteId_ = "";
         multiPartCounter_ = 0;
@@ -92,7 +92,7 @@ class Reply {
     bool finalPart_ = false;
 
     // Keep track of the number of body bytes received in request body.
-    int noBodyBytesReceived_ = -1;
+    size_t noBodyBytesReceived_ = 0;
 
     // Keep track if the body is a multi-part upload.
     bool isMultiPart_ = false;

--- a/src/request.hpp
+++ b/src/request.hpp
@@ -64,7 +64,7 @@ struct Request {
     }
 
     // returns number of body bytes in initial request buffer
-    int getNoInitialBodyBytesReceived() const {
+    size_t getNoInitialBodyBytesReceived() const {
         return noInitialBodyBytesReceived_;
     }
 
@@ -100,7 +100,7 @@ struct Request {
         return a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin(), ichar_equals);
     }
 
-    int noInitialBodyBytesReceived_ = -1;
+    size_t noInitialBodyBytesReceived_ = 0;
     size_t contentLength_ = 0;
 };
 

--- a/src/request_handler.cpp
+++ b/src/request_handler.cpp
@@ -6,7 +6,7 @@ namespace beauty {
 
 namespace {
 
-void defaultFileNotFoundHandler(const Request &req, Reply &rep) {
+void defaultFileNotFoundHandler(const Request&, Reply& rep) {
     rep.stockReply(Reply::not_found);
 }
 
@@ -92,7 +92,7 @@ void RequestHandler::handlePartialWrite(unsigned connectionId,
                                         std::vector<char> &content,
                                         Reply &rep) {
     std::deque<MultiPartParser::ContentPart> parts;
-    MultiPartParser::result_type result = rep.multiPartParser_.parse(req, content, parts);
+    MultiPartParser::result_type result = rep.multiPartParser_.parse(content, parts);
 
     if (result == MultiPartParser::result_type::bad) {
         rep.stockReply(Reply::status_type::bad_request);
@@ -113,7 +113,7 @@ void RequestHandler::handlePartialWrite(unsigned connectionId,
     }
 }
 
-void RequestHandler::closeFile(Reply &rep, unsigned connectionId) {
+void RequestHandler::closeFile(unsigned connectionId) {
     if (fileIO_ != nullptr) {
         fileIO_->closeReadFile(std::to_string(connectionId));
     }

--- a/src/request_handler.hpp
+++ b/src/request_handler.hpp
@@ -9,7 +9,7 @@
 namespace beauty {
 
 class IRouteHandler;
-struct Reply;
+class Reply;
 struct Request;
 
 class RequestHandler {
@@ -32,7 +32,7 @@ class RequestHandler {
                             const Request &req,
                             std::vector<char> &content,
                             Reply &rep);
-    void closeFile(Reply &rep, unsigned connectionId);
+    void closeFile(unsigned connectionId);
 
    private:
     bool openAndReadFile(unsigned connectionId, const Request &req, Reply &rep);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -4,6 +4,10 @@
 
 #include "server.hpp"
 
+namespace {
+	void defaultDebugMsgHandler(const std::string&) {}
+}
+
 namespace beauty {
 
 Server::Server(asio::io_context &ioContext,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(beauty_test)
 
-add_executable(beauty_test
+add_executable(${PROJECT_NAME}
 	server_test.cpp
 	file_io_test.cpp
 	request_parser_test.cpp
@@ -10,10 +10,11 @@ add_executable(beauty_test
 	${CMAKE_SOURCE_DIR}/examples/pc/file_io.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/utils/mock_file_io.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/utils/mock_request_handler.cpp
-	${Beauty_Sources}
 )
 
-target_link_libraries(beauty_test PRIVATE Catch2::Catch2WithMain asio::asio)
+target_link_libraries(${PROJECT_NAME} PRIVATE Catch2::Catch2WithMain asio::asio ${CMAKE_PROJECT_NAME})
+
+target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic -Werror)
 
 include_directories(
     ${CMAKE_SOURCE_DIR}/src
@@ -22,6 +23,6 @@ include_directories(
 
 # define tests
 add_test(
-	NAME beauty_test
-	COMMAND $<TARGET_FILE:beauty_test> --success
+	NAME ${PROJECT_NAME} 
+	COMMAND $<TARGET_FILE:${PROJECT_NAME}> --success
 )

--- a/test/request_parser_test.cpp
+++ b/test/request_parser_test.cpp
@@ -183,8 +183,7 @@ TEST_CASE("parse POST request partially", "[request_parser]") {
         "\r\n";
     const std::string body =
         "This request includes headers and some body data (this text) that does not fit the input "
-        "content buffer of 320 bytes.";
-    "\r\n";
+        "content buffer of 320 bytes.\r\n";
 
     auto result = fixture.parse(headers + body);
 

--- a/test/utils/mock_file_io.cpp
+++ b/test/utils/mock_file_io.cpp
@@ -6,18 +6,9 @@
 
 #include "file_io.hpp"
 
-namespace {
-bool ends_with(std::string const& value, std::string const& ending) {
-    if (ending.size() > value.size()) {
-        return false;
-    };
-    return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
-}
-}
-
 size_t MockFileIO::openFileForRead(const std::string& id,
-                                        const beauty::Request& request,
-                                        beauty::Reply& reply) {
+                                        const beauty::Request&,
+                                        beauty::Reply&) {
     OpenReadFile& openFile = openReadFiles_[id];
     countOpenFileForReadCalls_++;
     if (openFile.isOpen_) {
@@ -34,7 +25,7 @@ size_t MockFileIO::openFileForRead(const std::string& id,
 }
 
 int MockFileIO::readFile(const std::string& id,
-                              const beauty::Request& request,
+                              const beauty::Request&,
                               char* buf,
                               size_t maxSize) {
     OpenReadFile& openFile = openReadFiles_[id];
@@ -56,9 +47,9 @@ void MockFileIO::closeReadFile(const std::string& id) {
 
 beauty::Reply::status_type MockFileIO::openFileForWrite(
     const std::string& id,
-    const beauty::Request& request,
-    beauty::Reply& reply,
-    std::string& err) {
+    const beauty::Request&,
+    beauty::Reply&,
+    std::string&) {
     OpenWriteFile& openFile = openWriteFiles_[id];
     if (openFile.isOpen_) {
         throw std::runtime_error("MockFileIO test error: File already opened");
@@ -73,11 +64,11 @@ beauty::Reply::status_type MockFileIO::openFileForWrite(
 }
 
 beauty::Reply::status_type MockFileIO::writeFile(const std::string& id,
-                                                            const beauty::Request& request,
+                                                            const beauty::Request&,
                                                             const char* buf,
                                                             size_t size,
                                                             bool lastData,
-                                                            std::string& err) {
+                                                            std::string&) {
     OpenWriteFile& openFile = openWriteFiles_[id];
     if (!openFile.isOpen_) {
         throw std::runtime_error("MockFileIO test error: writeFile() called on closed file");

--- a/test/utils/mock_not_found_handler.hpp
+++ b/test/utils/mock_not_found_handler.hpp
@@ -8,7 +8,7 @@ class MockNotFoundHandler {
     MockNotFoundHandler() = default;
     virtual ~MockNotFoundHandler() = default;
 
-    void handleNotFound(const beauty::Request &req, beauty::Reply &rep) {
+    void handleNotFound(const beauty::Request&, beauty::Reply &rep) {
         noCalls_++;
         rep.content_.insert(rep.content_.begin(), mockedContent_.begin(), mockedContent_.end());
         rep.send(beauty::Reply::ok, "text/plain");

--- a/test/utils/test_client.hpp
+++ b/test/utils/test_client.hpp
@@ -67,7 +67,12 @@ class TestClient {
         std::unique_lock<std::mutex> lock(mutex_);
         auto test = gotResult_.wait_for(lock, std::chrono::seconds(2));
         if (test == std::cv_status::timeout) {
-            return {TestResult::TimedOut, {}};
+			TestResult ret;
+			ret.action_ = TestResult::TimedOut;
+			ret.statusCode_ = 0;
+			ret.headers_.clear();
+			ret.content_.clear();
+            return ret;
         }
         return testResult_;
     }


### PR DESCRIPTION
Follow up PR as the previous PR still resulted in some errors in the idf environment.

Also fixed all compiler compiler warnings (which now gives errors with -wError).

Also took the time to create better organisation of CMakeLists.txt. Now the target beauty_library is defined so that target_compile_options/set_target_properties can be individually for beauty_library/beauty_test/beauty_example.

