### PR TITLE
fix cjson_include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if(NOT IDF_PATH)
 
 	add_library(${CMAKE_PROJECT_NAME} STATIC ${beauty_sources})
 
-	target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE asio::asio)
+	target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE asio::asio cjson)
 
 	target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC 
 	    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
@@ -46,6 +46,4 @@ if(IDF_PATH)
 		INCLUDE_DIRS "src"
 		REQUIRES asio espressif__sock_utils
 	)
-	# Define preprocessor macro for conditional includes
-	target_compile_definitions(${COMPONENT_LIB} PUBLIC BEAUTY_ESP_IDF_BUILD=1)
 endif()

--- a/import/CMakeLists.txt
+++ b/import/CMakeLists.txt
@@ -19,3 +19,12 @@ CPMAddPackage(
 	"ENABLE_CJSON_TEST OFF"
 	"BUILD_SHARED_LIBS OFF"
 )
+
+# cJSON doesn't set include directories automatically, so we need to add them
+# https://github.com/DaveGamble/cJSON/issues/816
+if(json_ADDED)
+  target_include_directories(cjson INTERFACE 
+    $<BUILD_INTERFACE:${json_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+  )
+endif()

--- a/src/beauty_common.hpp
+++ b/src/beauty_common.hpp
@@ -7,13 +7,6 @@
 #include "reply.hpp"
 #include "request.hpp"
 
-// Conditional cJSON include for different environments
-#ifdef BEAUTY_ESP_IDF_BUILD
-#include "cJSON.h"
-#else
-#include "cjson/cJSON.h"
-#endif
-
 namespace beauty {
 
 using handlerCallback = std::function<void(const Request &req, Reply &rep)>;

--- a/src/http_result.hpp
+++ b/src/http_result.hpp
@@ -5,6 +5,8 @@
 #include <string>
 #include <sstream>
 #include <vector>
+
+#include "cJSON.h"
 #include "beauty_common.hpp"
 #include "reply.hpp"
 


### PR DESCRIPTION
Previously the cjson system install (if present) was used.
Now the CPM imported cjson is used as intended.

As a result the BEAUTY_ESP_IDF_BUILD could be removed.

Tested on system that do not have the cjson package installed that now build the project without problems.
