### PR TITLE
DEV-7658_Create_an_OpenApi_generator_for_Beauty

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,3 +359,105 @@ res << "Name,Age,City\n"
 
 rep.send(res.statusCode_, "text/csv");
 ```
+## Router (optional)
+
+Beauty provides a lightweight, router implementation. It avoids heavy dependencies like `std::regex` and uses string operations for path matching.
+
+### Features
+
+- **Lightweight**: No regex dependencies, uses simple string operations
+- **Embedded-friendly**: Minimal memory footprint and predictable performance
+- **Path Parameters**: Supports parameterized paths like `/users/{userId}`
+- **Multiple HTTP Methods**: Support for GET, POST, PUT, DELETE, etc.
+- **Easy Integration**: Designed to work seamlessly with Beauty's request handling
+
+### Basic Usage
+
+#### 1. Include the Router
+
+```cpp
+#include "beauty/router.hpp"
+```
+
+#### 2. Create and Configure Router
+
+```cpp
+beauty::Router router;
+
+// Add routes
+router.addRoute("GET", "/users", 
+    [](const beauty::Request& req, beauty::Reply& rep, const std::unordered_map<std::string, std::string>& params) {
+        // Handle GET /users
+    });
+
+router.addRoute("GET", "/users/{userId}", 
+    [](const beauty::Request& req, beauty::Reply& rep, const std::unordered_map<std::string, std::string>& params) {
+        std::string userId = params.at("userId");
+        // Handle GET /users/{userId}
+    });
+```
+
+#### 3. Handle Requests
+
+```cpp
+// Using the Router, a request handler is essentially implemented like this:
+void handleRequest(const beauty::Request& req, beauty::Reply& rep) {
+    if (router.handle(req, rep)) {
+        return; // Request was handled by router
+    }
+}
+```
+
+### Path Patterns
+
+The router supports simple path patterns with parameters:
+
+- `/users` - Exact match
+- `/users/{userId}` - Match with parameter
+- `/users/{userId}/posts/{postId}` - Multiple parameters
+- `/api/v1/users/{userId}` - Mixed literal and parameter segments
+
+#### Parameter Extraction
+
+Parameters are automatically extracted and passed to handlers:
+
+```cpp
+router.addRoute("GET", "/users/{userId}/posts/{postId}", 
+    [](const beauty::Request& req, beauty::Reply& rep, const std::map<std::string, std::string>& params) {
+        std::string userId = params.at("userId");
+        std::string postId = params.at("postId");
+        // Use the parameters...
+    });
+```
+
+### Complete Example
+
+See `my_router_api.cpp` for a complete working example that demonstrates:
+
+- Setting up multiple routes with different HTTP methods
+- Handling path parameters
+- Returning JSON responses
+- Integration with Beauty's HttpResult
+
+### Performance Characteristics
+
+- **Memory**: Minimal overhead, stores only parsed route segments
+- **CPU**: Simple string comparisons, no regex compilation or matching
+- **Predictable**: Linear time complexity O(n) where n is the number of route segments
+- **Embedded-friendly**: No dynamic regex compilation, fixed memory usage per route
+
+### Building and Testing
+
+The router is included in the Beauty examples CMake configuration. To build:
+
+```bash
+mkdir build && cd build
+cmake -DBUILD_EXAMPLES=On ..
+make
+```
+
+Start the example server and test the '/api/users' paths:
+
+```bash
+./build/examples/beauty_example 127.0.0.1 8080 www/
+```

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ router.addRoute("GET", "/users/{userId}",
 ```cpp
 // Using the Router, a request handler is essentially implemented like this:
 void handleRequest(const beauty::Request& req, beauty::Reply& rep) {
-    if (router.handle(req, rep)) {
+    if (router.handle(req, rep) == HandlerResult::Matched) {
         return; // Request was handled by router
     }
 }

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(${PROJECT_NAME}
 	pc/main.cpp
 	pc/file_io.cpp
 	pc/my_file_api.cpp
+	pc/my_router_api.cpp
 )
 
 include_directories(

--- a/examples/pc/main.cpp
+++ b/examples/pc/main.cpp
@@ -5,6 +5,7 @@
 
 #include "file_io.hpp"
 #include "my_file_api.hpp"
+#include "my_router_api.hpp"
 
 using namespace std::literals::chrono_literals;
 using namespace beauty;
@@ -26,8 +27,13 @@ int main(int argc, char *argv[]) {
         // Initialise the server.
         FileIO fileIO(argv[3]);
         HttpPersistence persistentOption(5s, 1000, 0);
-        MyFileApi fileApi(argv[3]);
         Server s(ioc, argv[1], argv[2], &fileIO, persistentOption, 1024);
+
+        MyRouterApi routerApi;
+        MyFileApi fileApi(argv[3]);
+        s.addRequestHandler(std::bind(&MyRouterApi::handleRequest, &routerApi, _1, _2));
+        // Must be placed last, after other middleware, as it (in this example)
+        // prepares filePath_ and and reply headers for FileIO.
         s.addRequestHandler(std::bind(&MyFileApi::handleRequest, &fileApi, _1, _2));
         s.setDebugMsgHandler([](const std::string &msg) { std::cout << msg << std::endl; });
 

--- a/examples/pc/my_router_api.cpp
+++ b/examples/pc/my_router_api.cpp
@@ -69,9 +69,10 @@ void MyRouterApi::setupRoutes() {
 
 // Main handler that Beauty will call
 void MyRouterApi::handleRequest(const Request& req, Reply& rep) {
-    if (router_.handle(req, rep) == HandlerResult::Matched) {
+    auto result = router_.handle(req, rep);
+    if (result == HandlerResult::Matched) {
         return;  // Request was handled by router
-    } else if (router_.handle(req, rep) == HandlerResult::MethodNotSupported) {
+    } else if (result == HandlerResult::MethodNotSupported) {
         // Method not supported for this path.
         // Note: HTTP 1.1 requires 405 "Method Not Allowed" to include the
         // "Allow" header

--- a/examples/pc/my_router_api.cpp
+++ b/examples/pc/my_router_api.cpp
@@ -1,0 +1,207 @@
+#include <beauty/http_result.hpp>
+#include <beauty/mime_types.hpp>
+
+#include "my_router_api.hpp"
+
+using namespace beauty;
+
+// Example usage of the Router
+// This shows how to integrate the router with Beauty web server
+MyRouterApi::MyRouterApi() {
+    setupRoutes();
+}
+
+void MyRouterApi::setupRoutes() {
+    // Route: GET /users
+    router_.addRoute("GET",
+                     "/api/users",
+                     [this](const Request& req,
+                            Reply& rep,
+                            const std::unordered_map<std::string, std::string>& params) {
+                         this->usersGet(req, rep, params);
+                     });
+
+    // Route: GET /users/{userId}
+    router_.addRoute("GET",
+                     "/api/users/{userId}",
+                     [this](const Request& req,
+                            Reply& rep,
+                            const std::unordered_map<std::string, std::string>& params) {
+                         this->usersUserIdGet(req, rep, params);
+                     });
+
+    // Route: POST /users
+    router_.addRoute("POST",
+                     "/api/users",
+                     [this](const Request& req,
+                            Reply& rep,
+                            const std::unordered_map<std::string, std::string>& params) {
+                         this->usersPost(req, rep, params);
+                     });
+
+    // Route: PUT /users/{userId}
+    router_.addRoute("PUT",
+                     "/api/users/{userId}",
+                     [this](const Request& req,
+                            Reply& rep,
+                            const std::unordered_map<std::string, std::string>& params) {
+                         this->usersUserIdPut(req, rep, params);
+                     });
+
+    // Route: DELETE /users/{userId}
+    router_.addRoute("DELETE",
+                     "/api/users/{userId}",
+                     [this](const Request& req,
+                            Reply& rep,
+                            const std::unordered_map<std::string, std::string>& params) {
+                         this->usersUserIdDelete(req, rep, params);
+                     });
+
+    // Route: GET /users/{userId}/posts/{postId}
+    router_.addRoute("GET",
+                     "/api/users/{userId}/posts/{postId}",
+                     [this](const Request& req,
+                            Reply& rep,
+                            const std::unordered_map<std::string, std::string>& params) {
+                         this->usersUserIdPostsPostIdGet(req, rep, params);
+                     });
+}
+
+// Main handler that Beauty will call
+void MyRouterApi::handleRequest(const Request& req, Reply& rep) {
+    if (router_.handle(req, rep) == HandlerResult::Matched) {
+        return;  // Request was handled by router
+    } else if (router_.handle(req, rep) == HandlerResult::MethodNotSupported) {
+        // Method not supported for this path.
+        // Note: HTTP 1.1 requires 405 "Method Not Allowed" to include the
+        // "Allow" header
+        rep.addHeader("Allow", router_.getAllowedMethodsWhenMethodNotSupported());
+        rep.send(Reply::status_type::method_not_allowed);
+        return;
+    }
+
+    // If no route matched let another handler or finally FileIO match the route.
+    // Beauty will return 404 Not Found if no other handler matches.
+}
+
+// Handler implementations
+void MyRouterApi::usersGet(const Request& /*req*/,
+                           Reply& rep,
+                           const std::unordered_map<std::string, std::string>& /*params*/) {
+    HttpResult result(rep.content_);
+    result.buildJsonResponse([&]() -> cJSON* {
+        cJSON* usersArray = cJSON_CreateArray();
+        // Add sample users
+        cJSON* user1 = cJSON_CreateObject();
+        cJSON_AddStringToObject(user1, "id", "1");
+        cJSON_AddStringToObject(user1, "name", "John Doe");
+        cJSON_AddItemToArray(usersArray, user1);
+
+        cJSON* user2 = cJSON_CreateObject();
+        cJSON_AddStringToObject(user2, "id", "2");
+        cJSON_AddStringToObject(user2, "name", "Jane Smith");
+        cJSON_AddItemToArray(usersArray, user2);
+
+        return usersArray;
+    });
+    rep.send(Reply::status_type::ok, "application/json");
+}
+
+void MyRouterApi::usersUserIdGet(const Request& /*req*/,
+                                 Reply& rep,
+                                 const std::unordered_map<std::string, std::string>& params) {
+    HttpResult result(rep.content_);
+    std::string userId = params.at("userId");
+
+    result.buildJsonResponse([&]() -> cJSON* {
+        cJSON* user = cJSON_CreateObject();
+        cJSON_AddStringToObject(user, "id", userId.c_str());
+        cJSON_AddStringToObject(user, "name", ("User " + userId).c_str());
+        cJSON_AddStringToObject(user, "email", ("user" + userId + "@example.com").c_str());
+        return user;
+    });
+    rep.send(Reply::status_type::ok, "application/json");
+}
+
+void MyRouterApi::usersPost(const Request& req,
+                            Reply& rep,
+                            const std::unordered_map<std::string, std::string>& /*params*/) {
+    HttpResult result(rep.content_);
+
+    if (!result.parseJsonRequest(req.body_)) {
+        result.jsonError(Reply::status_type::bad_request, "Invalid JSON in request");
+        rep.send(result.statusCode_, "application/json");
+        return;
+    }
+
+    // Here we would get the user properties here with
+    // result.getSingleValue("name"), etc. and create the user
+
+    result.buildJsonResponse([&]() -> cJSON* {
+        cJSON* response = cJSON_CreateObject();
+        cJSON_AddStringToObject(response, "message", "User created successfully");
+        cJSON_AddStringToObject(response, "id", "123");
+        return response;
+    });
+    rep.send(Reply::status_type::created, "application/json");
+}
+
+void MyRouterApi::usersUserIdPut(const Request& req,
+                                 Reply& rep,
+                                 const std::unordered_map<std::string, std::string>& params) {
+    HttpResult result(rep.content_);
+    std::string userId = params.at("userId");
+
+    if (!result.parseJsonRequest(req.body_)) {
+        result.jsonError(Reply::status_type::bad_request, "Invalid JSON in request");
+        rep.send(result.statusCode_, "application/json");
+        return;
+    }
+
+    // Here we would get the user properties here with
+    // result.getSingleValue("name"), etc. and update the user
+
+    result.buildJsonResponse([&]() -> cJSON* {
+        cJSON* response = cJSON_CreateObject();
+        cJSON_AddStringToObject(
+            response, "message", ("User " + userId + " updated successfully").c_str());
+        return response;
+    });
+    rep.send(Reply::status_type::ok, "application/json");
+}
+
+void MyRouterApi::usersUserIdDelete(const Request& /*req*/,
+                                    Reply& rep,
+                                    const std::unordered_map<std::string, std::string>& params) {
+    std::string userId = params.at("userId");
+
+    // Here we would delete the user with usersUserId
+
+    HttpResult result(rep.content_);
+    result.buildJsonResponse([&]() -> cJSON* {
+        cJSON* response = cJSON_CreateObject();
+        cJSON_AddStringToObject(
+            response, "message", ("User " + userId + " deleted successfully").c_str());
+        return response;
+    });
+    rep.send(Reply::status_type::ok, "application/json");
+}
+
+void MyRouterApi::usersUserIdPostsPostIdGet(
+    const Request& /*req*/,
+    Reply& rep,
+    const std::unordered_map<std::string, std::string>& params) {
+    std::string userId = params.at("userId");
+    std::string postId = params.at("postId");
+
+    HttpResult result(rep.content_);
+    result.buildJsonResponse([&]() -> cJSON* {
+        cJSON* post = cJSON_CreateObject();
+        cJSON_AddStringToObject(post, "id", postId.c_str());
+        cJSON_AddStringToObject(post, "userId", userId.c_str());
+        cJSON_AddStringToObject(post, "title", ("Post " + postId + " by User " + userId).c_str());
+        cJSON_AddStringToObject(post, "content", "This is the content of the post.");
+        return post;
+    });
+    rep.send(Reply::status_type::ok, "application/json");
+}

--- a/examples/pc/my_router_api.hpp
+++ b/examples/pc/my_router_api.hpp
@@ -1,0 +1,41 @@
+#pragma once
+#include <string>
+#include <functional>
+#include <unordered_map>
+#include <beauty/reply.hpp>
+#include <beauty/request.hpp>
+#include <beauty/router.hpp>
+
+// Example usage of the Router
+// This shows how to integrate the router with Beauty web server
+class MyRouterApi {
+   public:
+    MyRouterApi();
+    virtual ~MyRouterApi() = default;
+
+    void setupRoutes();
+    void handleRequest(const beauty::Request& req, beauty::Reply& rep);
+
+   private:
+    // Handler implementations
+    void usersGet(const beauty::Request& req,
+                  beauty::Reply& rep,
+                  const std::unordered_map<std::string, std::string>& params);
+    void usersUserIdGet(const beauty::Request& req,
+                        beauty::Reply& rep,
+                        const std::unordered_map<std::string, std::string>& params);
+    void usersPost(const beauty::Request& req,
+                   beauty::Reply& rep,
+                   const std::unordered_map<std::string, std::string>& params);
+    void usersUserIdPut(const beauty::Request& req,
+                        beauty::Reply& rep,
+                        const std::unordered_map<std::string, std::string>& params);
+    void usersUserIdDelete(const beauty::Request& req,
+                           beauty::Reply& rep,
+                           const std::unordered_map<std::string, std::string>& params);
+    void usersUserIdPostsPostIdGet(const beauty::Request& req,
+                                   beauty::Reply& rep,
+                                   const std::unordered_map<std::string, std::string>& params);
+
+    beauty::Router router_;
+};

--- a/src/beauty/reply.hpp
+++ b/src/beauty/reply.hpp
@@ -36,6 +36,7 @@ class Reply {
         unauthorized = 401,
         forbidden = 403,
         not_found = 404,
+		method_not_allowed = 405,
         internal_server_error = 500,
         not_implemented = 501,
         bad_gateway = 502,

--- a/src/beauty/reply.hpp
+++ b/src/beauty/reply.hpp
@@ -36,7 +36,7 @@ class Reply {
         unauthorized = 401,
         forbidden = 403,
         not_found = 404,
-		method_not_allowed = 405,
+        method_not_allowed = 405,
         internal_server_error = 500,
         not_implemented = 501,
         bad_gateway = 502,

--- a/src/beauty/router.hpp
+++ b/src/beauty/router.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <functional>
+#include <unordered_map>
+#include <string>
+#include <vector>
+
+#include <beauty/request.hpp>
+#include <beauty/reply.hpp>
+
+namespace beauty {
+
+enum class HandlerResult { Matched, MethodNotSupported, NoMatch };
+
+// A lightweight (optional) router to be used in added RequestHandlers
+class Router {
+   public:
+    using Handler = std::function<void(
+        const Request&, Reply&, const std::unordered_map<std::string, std::string>&)>;
+
+    // Add a route with method, path pattern and handler
+    void addRoute(const std::string& method, const std::string& pathPattern, Handler handler);
+
+    // Handle an incoming request
+    HandlerResult handle(const Request& req, Reply& rep);
+
+    // Get allowed methods for last MethodNotSupported result
+    const std::string& getAllowedMethodsWhenMethodNotSupported() const;
+
+   private:
+    struct RouteEntry {
+        std::vector<std::string> pathSegments;
+        std::vector<bool> isParameter;        // true if segment is a parameter
+        std::vector<std::string> paramNames;  // parameter names for segments that are parameters
+        Handler handler;
+    };
+
+    // Parse a path pattern into segments and parameter flags
+    RouteEntry parsePathPattern(const std::string& pathPattern, Handler handler);
+
+    // Split a path into segments
+    std::vector<std::string> splitPath(const std::string& path);
+
+    // Check if a request path matches a route pattern
+    bool matchPath(const RouteEntry& routeEntry,
+                   const std::string& requestPath,
+                   std::unordered_map<std::string, std::string>& params);
+
+    // Map of method to list of route entries
+    std::unordered_map<std::string, std::vector<RouteEntry>> routes_;
+
+    // Store allowed methods when method not supported
+    // Used to set "Allow" header in 405 responses
+    std::string allowedMethodsWhenMethodNotSupported_;
+};
+
+}  // namespace beauty

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -5,8 +5,6 @@
 namespace beauty {
 
 void Router::addRoute(const std::string& method, const std::string& pathPattern, Handler handler) {
-    // RouteEntry entry = parsePathPattern(pathPattern, handler);
-    // routes_[method].push_back(std::move(entry));
     RouteEntry entry = parsePathPattern(pathPattern, handler);
     auto& vec = routes_[method];
     vec.push_back(std::move(entry));

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -1,0 +1,154 @@
+#include <sstream>
+
+#include "beauty/router.hpp"
+
+namespace beauty {
+
+void Router::addRoute(const std::string& method, const std::string& pathPattern, Handler handler) {
+    // RouteEntry entry = parsePathPattern(pathPattern, handler);
+    // routes_[method].push_back(std::move(entry));
+    RouteEntry entry = parsePathPattern(pathPattern, handler);
+    auto& vec = routes_[method];
+    vec.push_back(std::move(entry));
+    // Sort: more literal segments (fewer parameters) first
+    std::sort(vec.begin(), vec.end(), [](const RouteEntry& a, const RouteEntry& b) {
+        int aParams = std::count(a.isParameter.begin(), a.isParameter.end(), true);
+        int bParams = std::count(b.isParameter.begin(), b.isParameter.end(), true);
+        return aParams < bParams;
+    });
+}
+
+HandlerResult Router::handle(const Request& req, Reply& rep) {
+    auto methodIt = routes_.find(req.method_);
+
+    // Try to match path+method first
+    if (methodIt != routes_.end()) {
+        for (const auto& routeEntry : methodIt->second) {
+            std::unordered_map<std::string, std::string> params;
+            if (matchPath(routeEntry, req.requestPath_, params)) {
+                routeEntry.handler(req, rep, params);
+                return HandlerResult::Matched;
+            }
+        }
+    }
+
+    // If not matched, check if path exists for any other method and collect allowed methods
+    if (req.httpVersionMajor_ == 1 && req.httpVersionMinor_ == 1) {
+        bool pathMatched = false;
+        std::ostringstream oss;
+        bool first = true;
+        for (const auto& it : routes_) {
+            const std::string& otherMethod = it.first;
+            if (otherMethod == req.method_) {
+                continue;
+            }
+            const std::vector<RouteEntry>& entries = it.second;
+            for (const auto& routeEntry : entries) {
+                std::unordered_map<std::string, std::string> params;
+                if (matchPath(routeEntry, req.requestPath_, params)) {
+                    if (!first) {
+                        oss << ", ";
+                    }
+                    oss << otherMethod;
+                    first = false;
+                    pathMatched = true;
+                    break;  // Only need to add each method once
+                }
+            }
+        }
+
+        if (pathMatched) {
+            allowedMethodsWhenMethodNotSupported_ = oss.str();
+            return HandlerResult::MethodNotSupported;
+        }
+    }
+
+    // No path matched at all
+    allowedMethodsWhenMethodNotSupported_.clear();
+    return HandlerResult::NoMatch;
+}
+
+const std::string& Router::getAllowedMethodsWhenMethodNotSupported() const {
+    return allowedMethodsWhenMethodNotSupported_;
+}
+
+Router::RouteEntry Router::parsePathPattern(const std::string& pathPattern, Handler handler) {
+    RouteEntry entry;
+    entry.handler = handler;
+
+    std::vector<std::string> segments = splitPath(pathPattern);
+
+    for (const std::string& segment : segments) {
+        if (segment.size() >= 2 && segment[0] == '{' && segment[segment.size() - 1] == '}') {
+            // This is a parameter
+            std::string paramName = segment.substr(1, segment.size() - 2);
+            entry.pathSegments.push_back(paramName);
+            entry.isParameter.push_back(true);
+            entry.paramNames.push_back(paramName);
+        } else {
+            // This is a literal segment
+            entry.pathSegments.push_back(segment);
+            entry.isParameter.push_back(false);
+            entry.paramNames.push_back("");  // Empty string for non-parameters
+        }
+    }
+
+    return entry;
+}
+
+std::vector<std::string> Router::splitPath(const std::string& path) {
+    std::vector<std::string> segments;
+
+    if (path.empty() || path == "/") {
+        return segments;
+    }
+
+    std::string cleanPath = path;
+    // Remove leading slash if present
+    if (cleanPath[0] == '/') {
+        cleanPath = cleanPath.substr(1);
+    }
+
+    if (cleanPath.empty()) {
+        return segments;
+    }
+
+    std::stringstream ss(cleanPath);
+    std::string segment;
+
+    while (std::getline(ss, segment, '/')) {
+        if (!segment.empty()) {
+            segments.push_back(segment);
+        }
+    }
+
+    return segments;
+}
+
+bool Router::matchPath(const RouteEntry& routeEntry,
+                       const std::string& requestPath,
+                       std::unordered_map<std::string, std::string>& params) {
+    std::vector<std::string> requestSegments = splitPath(requestPath);
+
+    // Check if segment counts match
+    if (requestSegments.size() != routeEntry.pathSegments.size()) {
+        return false;
+    }
+
+    // Check each segment
+    for (size_t i = 0; i < routeEntry.pathSegments.size(); ++i) {
+        if (routeEntry.isParameter[i]) {
+            // This is a parameter, extract it
+            params[routeEntry.paramNames[i]] = requestSegments[i];
+        } else {
+            // This is a literal segment, must match exactly
+            if (routeEntry.pathSegments[i] != requestSegments[i]) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+}  // namespace beauty

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(${PROJECT_NAME}
 	request_decoder_test.cpp
 	url_parser_test.cpp
 	http_result_test.cpp
+	router_test.cpp
 	${CMAKE_SOURCE_DIR}/examples/pc/file_io.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/utils/mock_file_io.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/utils/mock_request_handler.cpp

--- a/test/router_test.cpp
+++ b/test/router_test.cpp
@@ -1,0 +1,400 @@
+#include <set>
+#include <sstream>
+#include <cassert>
+#include <catch2/catch_test_macros.hpp>
+
+#include "beauty/router.hpp"
+
+using namespace beauty;
+
+namespace {
+// Helper to split comma-separated methods
+std::set<std::string> split_methods(const std::string& allow_header) {
+    std::set<std::string> methods;
+    std::istringstream iss(allow_header);
+    std::string method;
+    while (std::getline(iss, method, ',')) {
+        // Remove leading/trailing whitespace
+        method.erase(0, method.find_first_not_of(" \t"));
+        method.erase(method.find_last_not_of(" \t") + 1);
+        methods.insert(method);
+    }
+    return methods;
+}
+}  // namespace
+
+TEST_CASE("router functionality", "[router]") {
+    Router router;
+    bool handlerCalled = false;
+    std::unordered_map<std::string, std::string> capturedParams;
+
+    SECTION("should match route with parameter and extract param") {
+        // Add a test route
+        router.addRoute("GET",
+                        "/users/{userId}",
+                        [&](const Request&,
+                            Reply&,
+                            const std::unordered_map<std::string, std::string>& params) {
+                            handlerCalled = true;
+                            capturedParams = params;
+                        });
+
+        // Create a mock request
+        std::vector<char> body;
+        Request req(body);
+        req.method_ = "GET";
+        req.requestPath_ = "/users/123";
+
+        Reply rep(1024);
+
+        HandlerResult handled = router.handle(req, rep);
+
+        REQUIRE(handled == HandlerResult::Matched);
+        REQUIRE(handlerCalled == true);
+        REQUIRE(capturedParams.size() == 1);
+        REQUIRE(capturedParams["userId"] == "123");
+    }
+    SECTION(
+        "should return MethodNotSupported for HTTP 1.1 request and existing path with different "
+        "method") {
+        // Add a test route
+        router.addRoute(
+            "GET",
+            "/users/{userId}",
+            [&](const Request&, Reply&, const std::unordered_map<std::string, std::string>&) {});
+        router.addRoute(
+            "POST",
+            "/users/{userId}",
+            [&](const Request&, Reply&, const std::unordered_map<std::string, std::string>&) {});
+        router.addRoute(
+            "DELETE",
+            "/users/{userId}",
+            [&](const Request&, Reply&, const std::unordered_map<std::string, std::string>&) {});
+
+        // Create a mock request with different method
+        std::vector<char> body;
+        Request req(body);
+        req.method_ = "PUT";
+        req.requestPath_ = "/users/123";
+        req.httpVersionMajor_ = 1;
+        req.httpVersionMinor_ = 1;
+
+        Reply rep(1024);
+
+        HandlerResult handled = router.handle(req, rep);
+
+        REQUIRE(handled == HandlerResult::MethodNotSupported);
+        REQUIRE(handlerCalled == false);
+        auto allowedMethods = router.getAllowedMethodsWhenMethodNotSupported();
+        // Test allowed methods regardless of order
+        REQUIRE(split_methods(allowedMethods) == std::set<std::string>({"GET", "POST", "DELETE"}));
+    }
+    SECTION("should return NoMatch for HTTP 1.0 request and existing path with different method") {
+        // Add a test route
+        router.addRoute(
+            "GET",
+            "/users/{userId}",
+            [&](const Request&, Reply&, const std::unordered_map<std::string, std::string>&) {});
+        router.addRoute(
+            "POST",
+            "/users/{userId}",
+            [&](const Request&, Reply&, const std::unordered_map<std::string, std::string>&) {});
+        router.addRoute(
+            "DELETE",
+            "/users/{userId}",
+            [&](const Request&, Reply&, const std::unordered_map<std::string, std::string>&) {});
+
+        // Create a mock request with different method
+        std::vector<char> body;
+        Request req(body);
+        req.method_ = "PUT";
+        req.requestPath_ = "/users/123";
+        req.httpVersionMajor_ = 1;
+        req.httpVersionMinor_ = 0;
+
+        Reply rep(1024);
+
+        HandlerResult handled = router.handle(req, rep);
+
+        REQUIRE(handled == HandlerResult::NoMatch);
+        REQUIRE(handlerCalled == false);
+    }
+    SECTION("should return NoMatch for non-existing path") {
+        // Add a test route
+        router.addRoute(
+            "GET",
+            "/users/{userId}",
+            [&](const Request&, Reply&, const std::unordered_map<std::string, std::string>&) {});
+        // Create a mock request with non-matching path
+        std::vector<char> body;
+        Request req(body);
+        req.method_ = "GET";
+        req.requestPath_ = "/unknown/path";
+
+        Reply rep(1024);
+
+        HandlerResult handled = router.handle(req, rep);
+
+        REQUIRE(handled == HandlerResult::NoMatch);
+        REQUIRE(handlerCalled == false);
+    }
+    SECTION("should match route without parameters") {
+        // Add a test route
+        router.addRoute(
+            "GET",
+            "/status",
+            [&](const Request&, Reply&, const std::unordered_map<std::string, std::string>&) {
+                handlerCalled = true;
+            });
+
+        // Create a mock request
+        std::vector<char> body;
+        Request req(body);
+        req.method_ = "GET";
+        req.requestPath_ = "/status";
+
+        Reply rep(1024);
+
+        HandlerResult handled = router.handle(req, rep);
+
+        REQUIRE(handled == HandlerResult::Matched);
+        REQUIRE(handlerCalled == true);
+    }
+    SECTION("should not match partial paths") {
+        // Add a test route
+        router.addRoute(
+            "GET",
+            "/users/{userId}/posts/{postId}",
+            [&](const Request&, Reply&, const std::unordered_map<std::string, std::string>&) {
+                handlerCalled = true;
+            });
+
+        // Create a mock request with partial path
+        std::vector<char> body;
+        Request req(body);
+        req.method_ = "GET";
+        req.requestPath_ = "/users/123/posts";  // Missing postId
+
+        Reply rep(1024);
+
+        HandlerResult handled = router.handle(req, rep);
+
+        REQUIRE(handled == HandlerResult::NoMatch);
+        REQUIRE(handlerCalled == false);
+    }
+    SECTION("should match complex paths with multiple parameters") {
+        // Add a test route
+        router.addRoute("GET",
+                        "/users/{userId}/posts/{postId}",
+                        [&](const Request&,
+                            Reply&,
+                            const std::unordered_map<std::string, std::string>& params) {
+                            handlerCalled = true;
+                            capturedParams = params;
+                        });
+
+        // Create a mock request
+        std::vector<char> body;
+        Request req(body);
+        req.method_ = "GET";
+        req.requestPath_ = "/users/456/posts/789";
+
+        Reply rep(1024);
+
+        HandlerResult handled = router.handle(req, rep);
+
+        REQUIRE(handled == HandlerResult::Matched);
+        REQUIRE(handlerCalled == true);
+        REQUIRE(capturedParams.size() == 2);
+        REQUIRE(capturedParams["userId"] == "456");
+        REQUIRE(capturedParams["postId"] == "789");
+    }
+    SECTION("should handle empty path") {
+        // Add a test route for empty path
+        router.addRoute(
+            "GET",
+            "",
+            [&](const Request&, Reply&, const std::unordered_map<std::string, std::string>&) {
+                handlerCalled = true;
+            });
+
+        // Create a mock request with empty path
+        std::vector<char> body;
+        Request req(body);
+        req.method_ = "GET";
+        req.requestPath_ = "";
+
+        Reply rep(1024);
+
+        HandlerResult handled = router.handle(req, rep);
+
+        REQUIRE(handled == HandlerResult::Matched);
+        REQUIRE(handlerCalled == true);
+    }
+    SECTION("should handle root path") {
+        // Add a test route
+        router.addRoute(
+            "GET",
+            "/",
+            [&](const Request&, Reply&, const std::unordered_map<std::string, std::string>&) {
+                handlerCalled = true;
+            });
+
+        // Create a mock request
+        std::vector<char> body;
+        Request req(body);
+        req.method_ = "GET";
+        req.requestPath_ = "/";
+
+        Reply rep(1024);
+
+        HandlerResult handled = router.handle(req, rep);
+
+        REQUIRE(handled == HandlerResult::Matched);
+        REQUIRE(handlerCalled == true);
+    }
+    SECTION("should ignore trailing slashes in path matching") {
+        // Add a test route without trailing slash
+        router.addRoute(
+            "GET",
+            "/api/resource",
+            [&](const Request&, Reply&, const std::unordered_map<std::string, std::string>&) {
+                handlerCalled = true;
+            });
+
+        // Create a mock request with trailing slash
+        std::vector<char> body;
+        Request req(body);
+        req.method_ = "GET";
+        req.requestPath_ = "/api/resource/";
+
+        Reply rep(1024);
+
+        HandlerResult handled = router.handle(req, rep);
+
+        REQUIRE(handled == HandlerResult::Matched);
+        REQUIRE(handlerCalled == true);
+    }
+    SECTION("should ignore trailing slashes in route definition") {
+        // Add a test route without trailing slash
+        router.addRoute(
+            "GET",
+            "/api/resource/",
+            [&](const Request&, Reply&, const std::unordered_map<std::string, std::string>&) {
+                handlerCalled = true;
+            });
+
+        // Create a mock request without the trailing slash
+        std::vector<char> body;
+        Request req(body);
+        req.method_ = "GET";
+        req.requestPath_ = "/api/resource";
+
+        Reply rep(1024);
+
+        HandlerResult handled = router.handle(req, rep);
+
+        REQUIRE(handled == HandlerResult::Matched);
+        REQUIRE(handlerCalled == true);
+    }
+    SECTION("should handle multiple routes and match correct one") {
+        // Add multiple test routes
+        router.addRoute(
+            "POST",
+            "/items",
+            [&](const Request&, Reply&, const std::unordered_map<std::string, std::string>&) {
+                handlerCalled = true;
+            });
+        router.addRoute("GET",
+                        "/items/{itemId}",
+                        [&](const Request&,
+                            Reply&,
+                            const std::unordered_map<std::string, std::string>& params) {
+                            handlerCalled = true;
+                            capturedParams = params;
+                        });
+        router.addRoute(
+            "GET",
+            "/status",
+            [&](const Request&, Reply&, const std::unordered_map<std::string, std::string>&) {
+                handlerCalled = true;
+            });
+
+        // Create a mock request that should match the second route
+        std::vector<char> body;
+        Request req(body);
+        req.method_ = "GET";
+        req.requestPath_ = "/items/42";
+
+        Reply rep(1024);
+
+        HandlerResult handled = router.handle(req, rep);
+
+        REQUIRE(handled == HandlerResult::Matched);
+        REQUIRE(handlerCalled == true);
+        REQUIRE(capturedParams.size() == 1);
+        REQUIRE(capturedParams["itemId"] == "42");
+    }
+    SECTION("should handle overlapping routes and match most specific one") {
+        // Add overlapping test routes
+        router.addRoute("GET",
+                        "/files/{fileId}",
+                        [&](const Request&,
+                            Reply&,
+                            const std::unordered_map<std::string, std::string>& params) {
+                            handlerCalled = true;
+                            capturedParams = params;
+                        });
+        router.addRoute(
+            "GET",
+            "/files/special",
+            [&](const Request&, Reply&, const std::unordered_map<std::string, std::string>&) {
+                handlerCalled = true;
+                capturedParams.clear();
+                capturedParams["special"] = "true";
+            });
+
+        // Create a mock request that should match the more specific route
+        std::vector<char> body;
+        Request req(body);
+        req.method_ = "GET";
+        req.requestPath_ = "/files/special";
+
+        Reply rep(1024);
+
+        HandlerResult handled = router.handle(req, rep);
+
+        REQUIRE(handled == HandlerResult::Matched);
+        REQUIRE(handlerCalled == true);
+        REQUIRE(capturedParams.size() == 1);
+        REQUIRE(capturedParams["special"] == "true");
+    }
+    SECTION("should handle routes with similar prefixes") {
+        // Add routes with similar prefixes
+        router.addRoute(
+            "GET",
+            "/api/v1/resource",
+            [&](const Request&, Reply&, const std::unordered_map<std::string, std::string>&) {
+                handlerCalled = true;
+            });
+        router.addRoute("GET",
+                        "/api/v1/resource/{id}",
+                        [&](const Request&,
+                            Reply&,
+                            const std::unordered_map<std::string, std::string>& params) {
+                            handlerCalled = true;
+                            capturedParams = params;
+                        });
+        // Create a mock request that should match the second route
+        std::vector<char> body;
+        Request req(body);
+        req.method_ = "GET";
+        req.requestPath_ = "/api/v1/resource/99";
+        Reply rep(1024);
+        HandlerResult handled = router.handle(req, rep);
+        REQUIRE(handled == HandlerResult::Matched);
+        REQUIRE(handlerCalled == true);
+        REQUIRE(capturedParams.size() == 1);
+        REQUIRE(capturedParams["id"] == "99");
+    }
+}


### PR DESCRIPTION
This PR provides an optional path router to Beauty. This significantly helps the ongoing work with an OpenApi generator support for Beauty.

The provided router is optional, i.e. existing request handlers will continue to work as is. Focus has been to provide a lightweight router that may also be used in embedded systems.

The PR also adds the 405 status code. This is not supported in http 1.0 that Beauty currently supports. But as support for http 1.1 is immediately planned, I added this status code (its still the request handlers responsibility not use it for 1.0 compatibility) to make the example complete.

Tests:
* All project builds.
* All unit test pass.
* Tested all routes of the my_router_api example with postman and they work as expected (example of POST below).
<img width="1405" height="420" alt="image" src="https://github.com/user-attachments/assets/ad1c326c-3446-460a-a479-9b4cada69553" />
