### PR TITLE
DEV-7688 Make Beauty HTTP 1_1 compatible_2

### DIFF
--- a/src/beauty/request_parser.hpp
+++ b/src/beauty/request_parser.hpp
@@ -26,6 +26,8 @@ class RequestParser {
     // Handle the next character of input.
     result_type consume(Request &req, std::vector<char> &content, char input);
 
+    result_type actOnHeaderValueIfNeeded(Request &req, std::vector<char> &content);
+
     // The current state of the parser.
     enum state {
         method_start,


### PR DESCRIPTION
This PR investigates that the keep-alive handling is correct for HTTP 1.0/1.1 respectively.
And as far I can tell, it was already correct. I.e. HTTP/1.0 requires explicit that Conntection: keep-alive and for HTTP/1.1 it is default. However I found that the code was kind of hard to read and the Connection header was unnecessarily parsed in a seperate for loop (after all headers have been collected). So I refactored the code and added more tests.

Tests was done with curl .
**HTTP/1.0, no connection header**
<img width="656" height="316" alt="image" src="https://github.com/user-attachments/assets/cdf2a58b-df59-4c9a-b3fd-0ce86b4699fb" />

**HTTP/1.0, connection: keep-alive**
<img width="876" height="399" alt="image" src="https://github.com/user-attachments/assets/07549293-1765-4211-9c83-f32e9f776835" />

**HTTP/1.1, no connection header**
<img width="656" height="382" alt="image" src="https://github.com/user-attachments/assets/545c4bb0-b2b9-418e-854e-c446615057fe" />

**HTTP/1.1, connection: close**
<img width="840" height="350" alt="image" src="https://github.com/user-attachments/assets/e48fd32b-854f-4160-8d8a-98deeea596a0" />
