### PR TITLE
DEV-7688 Make Beauty HTTP 1_1 compatible_OPTIONS

### DIFF
--- a/src/beauty/router.hpp
+++ b/src/beauty/router.hpp
@@ -43,6 +43,9 @@ class Router {
                    const std::string& requestPath,
                    std::unordered_map<std::string, std::string>& params);
 
+    // Find all methods that support a given path
+    std::vector<std::string> findAllowedMethods(const std::string& requestPath);
+
     // Map of method to list of route entries
     std::unordered_map<std::string, std::vector<RouteEntry>> routes_;
 };


### PR DESCRIPTION
This PR adds support for method OPTIONS to router. It will return the Allow header for queried routes.
Comparison was made with express.js that seem to have the similar per route support only. However I noticed that express.js also provided a body (text /html with allowed methods). However AI recommended not to include this and referred to that as "bad practise". So I omitted response body. I also choose 200 as I found this note for 204 on mdn_:
"Note: Both [200 OK](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/200) and [204 No Content](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/204) are [permitted status codes](https://fetch.spec.whatwg.org/#ref-for-ok-status), but some browsers incorrectly believe 204 No Content applies to the resource and do not send a subsequent request to fetch it."

Tested with Postman on the my_routers_api:
<img width="1853" height="1116" alt="image" src="https://github.com/user-attachments/assets/aee24dc3-f084-4857-bb59-5191df895e53" />
